### PR TITLE
Fix initial data

### DIFF
--- a/e2e/registry.js
+++ b/e2e/registry.js
@@ -65,17 +65,17 @@ async function start(clean = false) {
   if (clean) {
     fs.rmSync('./build', { recursive: true, force: true });
   }
+  const components = ['react', 'es6', 'solid', 'vue' /*'preact', 'elm' */];
+
   console.log('Initializing components');
-  await initialize('react', clean);
-  // initialize("preact", clean);
-  await initialize('es6', clean);
-  await initialize('solid', clean);
-  await initialize('vue', clean);
-  await initialize('elm', clean);
+  for (const component of components) {
+    await initialize(component, clean);
+  }
 
   console.log('Starting dev server');
   cli.dev(
     {
+      components: components.map((c) => `base-component-${c}`),
       dirPath: './build',
       logger: {
         ok: console.log,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1711,14 +1711,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/jquery": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.29.tgz",
-      "integrity": "sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==",
-      "dependencies": {
-        "@types/sizzle": "*"
-      }
-    },
     "node_modules/@types/jsonfile": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
@@ -1786,11 +1778,6 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
       "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==",
       "dev": true
-    },
-    "node_modules/@types/sizzle": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
-      "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg=="
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.2.0",
@@ -5933,9 +5920,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "funding": [
         {
           "type": "opencollective",
@@ -5953,7 +5940,7 @@
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -6904,9 +6891,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8299,7 +8286,7 @@
       }
     },
     "packages/create-oc": {
-      "version": "0.0.19",
+      "version": "0.0.23",
       "license": "ISC",
       "dependencies": {
         "prompts": "^2.4.2"
@@ -8309,7 +8296,7 @@
       }
     },
     "packages/oc-server": {
-      "version": "0.4.2",
+      "version": "0.4.5",
       "license": "MIT"
     },
     "packages/oc-template-elm": {
@@ -8322,12 +8309,12 @@
       }
     },
     "packages/oc-template-elm-compiler": {
-      "version": "0.4.1",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "elm": "^0.19.1-6",
         "oc-template-elm": "0.1.1",
-        "oc-vite-compiler": "^3.6.1",
+        "oc-vite-compiler": "^3.7.1",
         "vite-plugin-elm": "^2.8.0"
       },
       "devDependencies": {
@@ -8348,13 +8335,13 @@
       }
     },
     "packages/oc-template-es6-compiler": {
-      "version": "4.1.1",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
         "oc-generic-template-compiler": "^2.1.4",
         "oc-statics-compiler": "2.1.1",
         "oc-template-es6": "^1.0.7",
-        "oc-vite-compiler": "^3.6.1"
+        "oc-vite-compiler": "^3.7.1"
       }
     },
     "packages/oc-template-preact": {
@@ -8369,12 +8356,12 @@
       }
     },
     "packages/oc-template-preact-compiler": {
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@preact/preset-vite": "^2.7.0",
         "oc-template-preact": "^0.1.1",
-        "oc-vite-compiler": "^3.6.1",
+        "oc-vite-compiler": "^3.7.1",
         "preact": "^10"
       },
       "devDependencies": {
@@ -8397,12 +8384,12 @@
       }
     },
     "packages/oc-template-react-compiler": {
-      "version": "6.2.1",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
         "@vitejs/plugin-react": "^4.0.0",
         "oc-template-react": "^4.0.2",
-        "oc-vite-compiler": "^3.6.1",
+        "oc-vite-compiler": "^3.7.1",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },
@@ -8424,11 +8411,11 @@
       }
     },
     "packages/oc-template-solid-compiler": {
-      "version": "0.8.2",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "oc-template-solid": "^0.1.2",
-        "oc-vite-compiler": "^3.6.1",
+        "oc-vite-compiler": "^3.7.1",
         "solid-js": "^1.8.7",
         "vite-plugin-solid": "^2.8.0"
       },
@@ -8447,12 +8434,12 @@
       }
     },
     "packages/oc-template-vue-compiler": {
-      "version": "0.3.1",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@vitejs/plugin-vue": "^4.5.2",
         "oc-template-vue": "^0.1.0",
-        "oc-vite-compiler": "^3.6.1"
+        "oc-vite-compiler": "^3.7.1"
       },
       "devDependencies": {
         "prettier": "^2.3.2",
@@ -8460,12 +8447,11 @@
       }
     },
     "packages/oc-vite": {
-      "version": "5.0.13",
+      "version": "5.1.0",
       "license": "MIT",
       "dependencies": {
-        "@types/jquery": "^3.5.29",
         "esbuild": "^0.19.3",
-        "postcss": "^8.4.32",
+        "postcss": "^8.4.35",
         "rollup": "^4.2.0"
       },
       "bin": {
@@ -8511,7 +8497,7 @@
       }
     },
     "packages/oc-vite-compiler": {
-      "version": "3.6.1",
+      "version": "3.7.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.18.9",
@@ -8523,7 +8509,7 @@
         "oc-hash-builder": "^1.0.5",
         "oc-statics-compiler": "^2.1.1",
         "oc-view-wrapper": "^1.0.6",
-        "oc-vite": "5.0.13",
+        "oc-vite": "5.1.0",
         "vite": "5.0.8",
         "vite-plugin-environment": "^1.1.3"
       },

--- a/packages/create-oc/CHANGELOG.md
+++ b/packages/create-oc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-oc
 
+## 0.0.24
+
+### Patch Changes
+
+- Fix initial data closure by always recreating component closure
+
 ## 0.0.12
 
 ### Patch Changes

--- a/packages/create-oc/package.json
+++ b/packages/create-oc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-oc",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "type": "module",
   "description": "",
   "main": "index.js",

--- a/packages/create-oc/templates/elm/package.json
+++ b/packages/create-oc/templates/elm/package.json
@@ -27,7 +27,7 @@
   "dependencies": {},
   "devDependencies": {
     "oc-server": "^0.4.5",
-    "oc-template-elm-compiler": "^0.5.0",
+    "oc-template-elm-compiler": "^0.5.1",
     "elm": "^0.19.1-6",
     "typescript": "^5.3.3"
   }

--- a/packages/create-oc/templates/es6/package.json
+++ b/packages/create-oc/templates/es6/package.json
@@ -25,6 +25,6 @@
   },
   "devDependencies": {
     "oc-server": "^0.4.5",
-    "oc-template-es6-compiler": "^4.2.0"
+    "oc-template-es6-compiler": "^4.2.1"
   }
 }

--- a/packages/create-oc/templates/preact/package.json
+++ b/packages/create-oc/templates/preact/package.json
@@ -35,7 +35,7 @@
     "@testing-library/user-event": "^14.4.3",
     "jsdom": "^21.1.1",
     "oc-server": "^0.4.5",
-    "oc-template-preact-compiler": "^0.6.0",
+    "oc-template-preact-compiler": "^0.6.1",
     "preact": "^10.13.2",
     "typescript": "5.0.2",
     "vitest": "^0.29.7"

--- a/packages/create-oc/templates/react/package.json
+++ b/packages/create-oc/templates/react/package.json
@@ -35,7 +35,7 @@
     "@types/react": "^18.0.28",
     "jsdom": "^21.1.1",
     "oc-server": "^0.4.5",
-    "oc-template-react-compiler": "^6.3.0",
+    "oc-template-react-compiler": "^6.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.1.3",

--- a/packages/create-oc/templates/solid/package.json
+++ b/packages/create-oc/templates/solid/package.json
@@ -34,7 +34,7 @@
     "@types/testing-library__jest-dom": "^5.14.5",
     "jsdom": "^21.1.1",
     "oc-server": "^0.4.5",
-    "oc-template-solid-compiler": "^0.9.0",
+    "oc-template-solid-compiler": "^0.9.1",
     "solid-js": "^1.8.7",
     "typescript": "5.0.2",
     "vitest": "^0.29.7"

--- a/packages/create-oc/templates/vue/package.json
+++ b/packages/create-oc/templates/vue/package.json
@@ -34,7 +34,7 @@
     "@vitejs/plugin-vue": "^5.0.0",
     "jsdom": "^21.1.1",
     "oc-server": "^0.4.5",
-    "oc-template-vue-compiler": "^0.4.0",
+    "oc-template-vue-compiler": "^0.4.1",
     "typescript": "5.0.2",
     "vitest": "^0.29.7",
     "vue": "^3.3.11",

--- a/packages/oc-template-elm-compiler/CHANGELOG.md
+++ b/packages/oc-template-elm-compiler/CHANGELOG.md
@@ -1,5 +1,13 @@
 # oc-template-elm-compiler
 
+## 0.5.2
+
+### Patch Changes
+
+- Fix initial data closure by always recreating component closure
+- Updated dependencies
+  - oc-vite-compiler@3.7.2
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/oc-template-elm-compiler/package.json
+++ b/packages/oc-template-elm-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-template-elm-compiler",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Compiler for the Elm OC template",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -30,7 +30,7 @@
   "dependencies": {
     "elm": "^0.19.1-6",
     "oc-template-elm": "0.1.1",
-    "oc-vite-compiler": "^3.7.1",
+    "oc-vite-compiler": "^3.7.2",
     "vite-plugin-elm": "^2.8.0"
   },
   "files": [

--- a/packages/oc-template-elm-compiler/scaffold/src/package.json
+++ b/packages/oc-template-elm-compiler/scaffold/src/package.json
@@ -27,7 +27,7 @@
   "dependencies": {},
   "devDependencies": {
     "oc-server": "^0.4.5",
-    "oc-template-elm-compiler": "^0.5.0",
+    "oc-template-elm-compiler": "^0.5.1",
     "elm": "^0.19.1-6",
     "typescript": "^5.3.3"
   }

--- a/packages/oc-template-es6-compiler/CHANGELOG.md
+++ b/packages/oc-template-es6-compiler/CHANGELOG.md
@@ -1,5 +1,13 @@
 # oc-template-es6-compiler
 
+## 4.2.2
+
+### Patch Changes
+
+- Fix initial data closure by always recreating component closure
+- Updated dependencies
+  - oc-vite-compiler@3.7.2
+
 ## 4.2.1
 
 ### Patch Changes

--- a/packages/oc-template-es6-compiler/package.json
+++ b/packages/oc-template-es6-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-template-es6-compiler",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Compiler for the ES6 OC template",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,7 +29,7 @@
     "oc-generic-template-compiler": "^2.1.4",
     "oc-statics-compiler": "2.1.1",
     "oc-template-es6": "^1.0.7",
-    "oc-vite-compiler": "^3.7.1"
+    "oc-vite-compiler": "^3.7.2"
   },
   "files": [
     "dist/**",

--- a/packages/oc-template-es6-compiler/scaffold/src/package.json
+++ b/packages/oc-template-es6-compiler/scaffold/src/package.json
@@ -25,6 +25,6 @@
   },
   "devDependencies": {
     "oc-server": "^0.4.5",
-    "oc-template-es6-compiler": "^4.2.0"
+    "oc-template-es6-compiler": "^4.2.1"
   }
 }

--- a/packages/oc-template-preact-compiler/CHANGELOG.md
+++ b/packages/oc-template-preact-compiler/CHANGELOG.md
@@ -1,5 +1,13 @@
 # oc-template-preact-compiler
 
+## 0.6.2
+
+### Patch Changes
+
+- Fix initial data closure by always recreating component closure
+- Updated dependencies
+  - oc-vite-compiler@3.7.2
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/oc-template-preact-compiler/package.json
+++ b/packages/oc-template-preact-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-template-preact-compiler",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Compiler for the Preact OC template",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -30,7 +30,7 @@
   "dependencies": {
     "@preact/preset-vite": "^2.7.0",
     "oc-template-preact": "^0.1.1",
-    "oc-vite-compiler": "^3.7.1",
+    "oc-vite-compiler": "^3.7.2",
     "preact": "^10"
   },
   "peerDependencies": {

--- a/packages/oc-template-preact-compiler/scaffold/src/package.json
+++ b/packages/oc-template-preact-compiler/scaffold/src/package.json
@@ -35,7 +35,7 @@
     "@testing-library/user-event": "^14.4.3",
     "jsdom": "^21.1.1",
     "oc-server": "^0.4.5",
-    "oc-template-preact-compiler": "^0.6.0",
+    "oc-template-preact-compiler": "^0.6.1",
     "preact": "^10.13.2",
     "typescript": "5.0.2",
     "vitest": "^0.29.7"

--- a/packages/oc-template-react-compiler/CHANGELOG.md
+++ b/packages/oc-template-react-compiler/CHANGELOG.md
@@ -1,5 +1,13 @@
 # oc-template-react-compiler
 
+## 6.3.2
+
+### Patch Changes
+
+- Fix initial data closure by always recreating component closure
+- Updated dependencies
+  - oc-vite-compiler@3.7.2
+
 ## 6.3.1
 
 ### Patch Changes

--- a/packages/oc-template-react-compiler/package.json
+++ b/packages/oc-template-react-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-template-react-compiler",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "Compiler for the React OC template",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -30,7 +30,7 @@
   "dependencies": {
     "@vitejs/plugin-react": "^4.0.0",
     "oc-template-react": "^4.0.2",
-    "oc-vite-compiler": "^3.7.1",
+    "oc-vite-compiler": "^3.7.2",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/packages/oc-template-react-compiler/scaffold/src/package.json
+++ b/packages/oc-template-react-compiler/scaffold/src/package.json
@@ -35,7 +35,7 @@
     "@types/react": "^18.0.28",
     "jsdom": "^21.1.1",
     "oc-server": "^0.4.5",
-    "oc-template-react-compiler": "^6.3.0",
+    "oc-template-react-compiler": "^6.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.1.3",

--- a/packages/oc-template-solid-compiler/CHANGELOG.md
+++ b/packages/oc-template-solid-compiler/CHANGELOG.md
@@ -1,5 +1,13 @@
 # oc-template-solid-compiler
 
+## 0.9.2
+
+### Patch Changes
+
+- Fix initial data closure by always recreating component closure
+- Updated dependencies
+  - oc-vite-compiler@3.7.2
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/oc-template-solid-compiler/package.json
+++ b/packages/oc-template-solid-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-template-solid-compiler",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Compiler for the SolidJS OC template",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "oc-template-solid": "^0.1.2",
-    "oc-vite-compiler": "^3.7.1",
+    "oc-vite-compiler": "^3.7.2",
     "solid-js": "^1.8.7",
     "vite-plugin-solid": "^2.8.0"
   },

--- a/packages/oc-template-solid-compiler/scaffold/src/package.json
+++ b/packages/oc-template-solid-compiler/scaffold/src/package.json
@@ -34,7 +34,7 @@
     "@types/testing-library__jest-dom": "^5.14.5",
     "jsdom": "^21.1.1",
     "oc-server": "^0.4.5",
-    "oc-template-solid-compiler": "^0.9.0",
+    "oc-template-solid-compiler": "^0.9.1",
     "solid-js": "^1.8.7",
     "typescript": "5.0.2",
     "vitest": "^0.29.7"

--- a/packages/oc-template-vue-compiler/CHANGELOG.md
+++ b/packages/oc-template-vue-compiler/CHANGELOG.md
@@ -1,5 +1,13 @@
 # oc-template-vue-compiler
 
+## 0.4.2
+
+### Patch Changes
+
+- Fix initial data closure by always recreating component closure
+- Updated dependencies
+  - oc-vite-compiler@3.7.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/oc-template-vue-compiler/package.json
+++ b/packages/oc-template-vue-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-template-vue-compiler",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Compiler for the vueJS OC template",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -30,7 +30,7 @@
   "dependencies": {
     "@vitejs/plugin-vue": "^4.5.2",
     "oc-template-vue": "^0.1.0",
-    "oc-vite-compiler": "^3.7.1"
+    "oc-vite-compiler": "^3.7.2"
   },
   "files": [
     "dist/**",

--- a/packages/oc-template-vue-compiler/scaffold/src/package.json
+++ b/packages/oc-template-vue-compiler/scaffold/src/package.json
@@ -34,7 +34,7 @@
     "@vitejs/plugin-vue": "^5.0.0",
     "jsdom": "^21.1.1",
     "oc-server": "^0.4.5",
-    "oc-template-vue-compiler": "^0.4.0",
+    "oc-template-vue-compiler": "^0.4.1",
     "typescript": "5.0.2",
     "vitest": "^0.29.7",
     "vue": "^3.3.11",

--- a/packages/oc-vite-compiler/CHANGELOG.md
+++ b/packages/oc-vite-compiler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # oc-vite-compiler
 
+## 3.7.2
+
+### Patch Changes
+
+- Fix initial data closure by always recreating component closure
+
 ## 3.7.1
 
 ### Patch Changes

--- a/packages/oc-vite-compiler/package.json
+++ b/packages/oc-vite-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-vite-compiler",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "OC-Vite-Compiler",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/oc-vite-compiler/src/lib/htmlTemplate.ts
+++ b/packages/oc-vite-compiler/src/lib/htmlTemplate.ts
@@ -22,7 +22,7 @@ export default function htmlTemplate({
 }: HtmlTemplate) {
   return `function(model){
   oc.${templateName}Components = oc.${templateName}Components || {};
-  oc.${templateName}Components['${hash}'] = oc.${templateName}Components['${hash}'] || (${bundle});
+  oc.${templateName}Components['${hash}'] = (${bundle});
   if (!model) return;
   var modelHTML =  model.__html ? model.__html : '';
   var ssr = !!modelHTML;


### PR DESCRIPTION
getInitialData wasn't working correctly, since window.oc.[template]Components was created only once, and then all instances would use the same initial data from the closure above. This fixes it by, on htmlTemplate, always recreate it.