### PR TITLE
Upgrade Solid to require patched seroval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8174,14 +8174,14 @@
       }
     },
     "node_modules/solid-js": {
-      "version": "1.9.13",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.13.tgz",
-      "integrity": "sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ==",
+      "version": "1.9.14",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.14.tgz",
+      "integrity": "sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.0",
-        "seroval": "~1.5.0",
-        "seroval-plugins": "~1.5.0"
+        "seroval": "~1.5.4",
+        "seroval-plugins": "~1.5.4"
       }
     },
     "node_modules/solid-refresh": {
@@ -10523,7 +10523,7 @@
       "dependencies": {
         "nice-cache": "0.0.5",
         "oc-generic-template-renderer": "2.0.9",
-        "solid-js": "^1.8.21"
+        "solid-js": "^1.9.14"
       }
     },
     "packages/oc-template-solid-compiler": {
@@ -10532,7 +10532,7 @@
       "dependencies": {
         "oc-template-solid": "^0.1.3",
         "oc-vite-compiler": "^6.0.2",
-        "solid-js": "^1.8.7",
+        "solid-js": "^1.9.14",
         "vite-plugin-solid": "^2.8.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7968,9 +7968,9 @@
       "license": "MIT"
     },
     "node_modules/seroval": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
-      "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
+      "integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   "workspaces": [
     "packages/*"
   ],
-  "packageManager": "npm@11.5.1"
+  "packageManager": "npm@11.5.1",
+  "overrides": {
+    "seroval": "1.5.6"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,5 @@
   "workspaces": [
     "packages/*"
   ],
-  "packageManager": "npm@11.5.1",
-  "overrides": {
-    "seroval": "1.5.6"
-  }
+  "packageManager": "npm@11.5.1"
 }

--- a/packages/create-oc/templates/solid/package.json
+++ b/packages/create-oc/templates/solid/package.json
@@ -28,7 +28,7 @@
     "jsdom": "^21.1.1",
     "oc-server": "^4.0.2",
     "oc-template-solid-compiler": "^4.0.1",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.14",
     "typescript": "5.5.4",
     "vite": "^7.1.12",
     "vitest": "^2.0.5"

--- a/packages/oc-template-solid-compiler/package.json
+++ b/packages/oc-template-solid-compiler/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "oc-template-solid": "^0.1.3",
     "oc-vite-compiler": "^6.0.2",
-    "solid-js": "^1.8.7",
+    "solid-js": "^1.9.14",
     "vite-plugin-solid": "^2.8.0"
   },
   "files": [

--- a/packages/oc-template-solid-compiler/scaffold/src/package.json
+++ b/packages/oc-template-solid-compiler/scaffold/src/package.json
@@ -28,7 +28,7 @@
     "jsdom": "^21.1.1",
     "oc-server": "^4.0.2",
     "oc-template-solid-compiler": "^4.0.1",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.14",
     "typescript": "5.5.4",
     "vite": "^7.1.12",
     "vitest": "^2.0.5"

--- a/packages/oc-template-solid/package.json
+++ b/packages/oc-template-solid/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "nice-cache": "0.0.5",
     "oc-generic-template-renderer": "2.0.9",
-    "solid-js": "^1.8.21"
+    "solid-js": "^1.9.14"
   },
   "files": [
     "dist/**"


### PR DESCRIPTION
## Summary
- upgrade Solid dependencies and generated Solid scaffolds to `solid-js ^1.9.14`
- refresh the lockfile so Solid requires `seroval ~1.5.4`, excluding versions affected by CVE-2026-59940
- avoid a root npm override, allowing the safe dependency constraint to propagate to consumers

#### Test plan
- [x] `npm run build`
- [x] `npm run lint` (no lint tasks configured)
- [x] confirm `npm audit --omit=dev` does not report `seroval`
- [x] confirm `npm ls` resolves `solid-js@1.9.14` and `seroval@1.5.6`

Generated with [Devin](https://devin.ai)