### PR TITLE
feat(esm): resolve the shadow root and expose it on the mount context

### DIFF
--- a/.changeset/shadow-dom-mount-primitives.md
+++ b/.changeset/shadow-dom-mount-primitives.md
@@ -1,0 +1,17 @@
+---
+'oc-template-esm-compiler': minor
+---
+
+Resolve the shadow root a component is mounted in and expose it on the mount context.
+
+The `mount` context now includes `shadowRoot` (alongside the existing
+`styleElement`/`styleId`), populated both when the component creates its own
+shadow root via `oc.files.template.shadowDOM` and when the embedding page mounts
+the component inside a shadow root it owns. Detection uses `element.getRootNode()`
+instead of a manual `parentNode` walk, so closed and nested shadow roots are
+handled correctly.
+
+A `getShadowRoot(node)` helper is also exported from
+`oc-template-esm-compiler/renderer` for use outside `mount`. The template stays
+framework-agnostic: it reports where the component is rendered and leaves all
+styling and DOM decisions to the component.

--- a/packages/oc-template-esm-compiler/README.md
+++ b/packages/oc-template-esm-compiler/README.md
@@ -1,3 +1,61 @@
 # oc-template-esm-compiler - Compiler module
 
 OC template to compile components of type `oc-template-esm`
+
+## The mount context
+
+Components created with `createComponent` receive a **context** object as the
+third argument of `mount(element, props, context)`:
+
+```ts
+type RendererContext = {
+  // The shadow root the component renders inside, or `null` in the light DOM.
+  shadowRoot?: ShadowRoot | null;
+  // The <style> element the compiler injected for this component (and its id).
+  styleElement?: HTMLStyleElement | null;
+  styleId?: string;
+};
+```
+
+The template resolves `shadowRoot` for you in both cases where a component ends
+up inside a shadow root:
+
+- when the component opts into an isolated shadow root itself via
+  `oc.files.template.shadowDOM`, and
+- when the page embedding the component mounts it inside a shadow root it owns.
+
+Detection uses the standard `element.getRootNode()` API, so closed and nested
+shadow roots are handled correctly and components never need to walk `parentNode`
+to find the root themselves.
+
+What a component does with that information — where to inject its runtime styles,
+where to render portals/overlays so they stay within the shadow boundary — is up
+to the component and its rendering libraries. The template only tells it where it
+is; it deliberately doesn't reach into the component's styling or DOM.
+
+```tsx
+import { createComponent } from 'oc-template-esm-compiler/renderer';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+export default createComponent(() => {
+  let root;
+  return {
+    mount(element, props, { shadowRoot }) {
+      root = createRoot(element);
+      root.render(<App {...props} shadowRoot={shadowRoot} />);
+    },
+    unmount() {
+      root?.unmount();
+    }
+  };
+});
+```
+
+The same detection is exported as a standalone helper if you need it elsewhere:
+
+```ts
+import { getShadowRoot } from 'oc-template-esm-compiler/renderer';
+
+const shadowRoot = getShadowRoot(element); // ShadowRoot | null
+```

--- a/packages/oc-template-esm-compiler/src/lib/esmOCProviderTemplate.ts
+++ b/packages/oc-template-esm-compiler/src/lib/esmOCProviderTemplate.ts
@@ -13,6 +13,7 @@ export default function esmOCProviderTemplate({
 }) {
   return `
   import Component from '${removeExtension(viewPath)}';
+  import { getShadowRoot } from 'oc-template-esm-compiler/renderer';
 
   export function mount(element, props, ctx = {}) {
     const { _staticPath, _baseUrl, _componentName, _componentVersion, ...rest } = props;
@@ -47,21 +48,18 @@ export default function esmOCProviderTemplate({
    }
     const styleElement = ${styleId ? `document.getElementById('${styleId}')` : 'null'};
     const styleId = ${styleId ? `'${styleId}'` : 'undefined'};
-    let shadowRoot = undefined;
     const methods = typeof Component === 'function' ? Component() : Component;
 
     ${
-      // If shadowRootMode is set at build time, attach a shadow root and mount into it
-      // We also clone the styleElement into the shadow root when present
-      // Closed mode returns null on element.shadowRoot; we still pass the value we hold
-      // via local variable for consumers that need it.
-      // Note: we mount into a container div to not clobber host shadow contents.
-      // If no shadowRootMode, mount into light DOM as before.
+      // If shadowDOM is set at build time we attach a shadow root and mount into
+      // a container inside it, cloning the styleElement so styles apply in scope.
+      // Closed mode returns null on element.shadowRoot; we still pass the value
+      // we hold via the context for consumers that need it.
       `
     if (${shadowDOM ? 'true' : 'false'}) {
       const mode = ${shadowDOM === true ? "'open'" : `'${shadowDOM}'`};
       element.innerHTML = '';
-      shadowRoot = element.attachShadow({ mode });
+      const shadowRoot = element.attachShadow({ mode });
       if (styleElement && shadowRoot) {
         const clone = styleElement.cloneNode(true);
         // Original style element has type='oc/css' so styles dont apply to global scope
@@ -72,14 +70,18 @@ export default function esmOCProviderTemplate({
       const container = document.createElement('div');
       shadowRoot.appendChild(container);
       element.unmount = () => methods.unmount?.();
-      methods.mount(container, rest, { shadowRoot });
+      methods.mount(container, rest, { shadowRoot, styleElement, styleId });
       return;
     }
       `
     }
 
+    // The mount element may already live inside a shadow root that the embedding
+    // page owns; resolve it so the component can adapt (styles, portals, ...).
+    // No shadow root -> light DOM, shadowRoot is null.
+    const shadowRoot = getShadowRoot(element);
     element.unmount = () => methods.unmount?.();
-    methods.mount(element, rest, { styleElement, styleId, shadowRoot: null });
+    methods.mount(element, rest, { shadowRoot, styleElement, styleId });
   }
 `;
 }

--- a/packages/oc-template-esm-compiler/src/lib/renderer.test.ts
+++ b/packages/oc-template-esm-compiler/src/lib/renderer.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { getShadowRoot } from './renderer.js';
+
+// Minimal DOM-ish fake so the shadow-root resolution can be exercised without
+// pulling in a full DOM environment.
+function elementWithRoot(rootNode: unknown): Node {
+  return { getRootNode: () => rootNode } as unknown as Node;
+}
+
+describe('getShadowRoot', () => {
+  it('returns null when the node is in the light DOM (Document root)', () => {
+    const documentRoot = { nodeType: 9 }; // DOCUMENT_NODE
+    expect(getShadowRoot(elementWithRoot(documentRoot))).toBeNull();
+  });
+
+  it('returns the shadow root when the node lives inside one', () => {
+    const shadowRoot = { nodeType: 11, host: {} };
+    expect(getShadowRoot(elementWithRoot(shadowRoot))).toBe(shadowRoot);
+  });
+
+  it('does not treat a plain DocumentFragment (no host) as a shadow root', () => {
+    const fragment = { nodeType: 11 }; // no `host`
+    expect(getShadowRoot(elementWithRoot(fragment))).toBeNull();
+  });
+
+  it('returns null when getRootNode is unavailable', () => {
+    expect(getShadowRoot({} as unknown as Node)).toBeNull();
+  });
+});

--- a/packages/oc-template-esm-compiler/src/lib/renderer.ts
+++ b/packages/oc-template-esm-compiler/src/lib/renderer.ts
@@ -1,14 +1,48 @@
 import type { InitialData } from 'oc-server/client';
 
-type RendererContext = {
+/**
+ * Context passed to a component's `mount` function as the third argument.
+ *
+ * It tells the component where it is being rendered so it can adapt if needed —
+ * in particular whether it lives inside a shadow root (one the template created
+ * via `oc.files.template.shadowDOM`, or one owned by the page embedding the
+ * component). The template resolves this for you, so components don't have to
+ * walk the DOM to discover a shadow root themselves.
+ */
+export type RendererContext = {
+  /**
+   * The shadow root the component is rendered inside, or `null` when it renders
+   * in the light DOM.
+   */
   shadowRoot?: ShadowRoot | null;
+  /** The `<style>` element the compiler injected for this component, if any. */
+  styleElement?: HTMLStyleElement | null;
+  /** The id of the `<style>` element the compiler injected, if any. */
+  styleId?: string;
 };
 
-interface RendererOptions {
+export interface RendererOptions {
   mount(element: Element, props: InitialData, context: RendererContext): void;
   unmount?(): void;
 }
 
-export function createComponent(opts: RendererOptions | (() => RendererOptions)) {
+export function createComponent(
+  opts: RendererOptions | (() => RendererOptions)
+) {
   return opts;
+}
+
+/**
+ * Returns the shadow root the given node lives inside, or `null` when it is in
+ * the light DOM. Uses the standard `getRootNode()` API rather than manually
+ * walking `parentNode`, so closed and nested shadow roots are handled correctly.
+ */
+export function getShadowRoot(node: Node): ShadowRoot | null {
+  const root =
+    typeof node.getRootNode === 'function' ? node.getRootNode() : null;
+  return root &&
+    root.nodeType === 11 /* Node.DOCUMENT_FRAGMENT_NODE */ &&
+    'host' in root
+    ? (root as ShadowRoot)
+    : null;
 }

--- a/packages/oc-template-esm-compiler/tsconfig.json
+++ b/packages/oc-template-esm-compiler/tsconfig.json
@@ -16,5 +16,6 @@
     "composite": true,
     "declarationMap": true,
   },
-  "include": ["./src"]
+  "include": ["./src"],
+  "exclude": ["./src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

A component compiled with this template can end up inside a shadow root in two ways:

- it opts into an isolated shadow root itself via `oc.files.template.shadowDOM`, or
- the page embedding it mounts it inside a shadow root that page owns.

In the second case a component previously had no way to know, and had to walk `parentNode` itself to discover the root. This resolves the shadow root in the template and passes it to the component so it can adapt if it needs to.

## What changed

- The `mount(element, props, context)` context now includes `shadowRoot` (alongside the existing `styleElement`/`styleId`). It is populated for both the template-owned and page-owned shadow root cases.
- Detection uses the standard `element.getRootNode()`, so closed and nested shadow roots are handled correctly — no manual `parentNode` walking.
- Exported a small `getShadowRoot(node)` helper from `oc-template-esm-compiler/renderer` for use outside `mount`.
- Documented the mount context in the package README.

The template deliberately stays out of the component's business: it reports *where* the component is rendered and does not touch styling or DOM. What to do with a shadow root (where to inject styles, where to render portals) is left entirely to the component and its rendering libraries.

## Consumer impact

Backwards compatible — the context only gains a field. Components that ignore it keep working, and `shadowRoot` is `null` in the light DOM.

#### Test plan

- [x] `turbo build` passes for the whole repo
- [x] Unit tests for `getShadowRoot` (light DOM, shadow root, plain fragment, missing `getRootNode`)

Generated with [Devin](https://devin.ai)
